### PR TITLE
Snapd fix

### DIFF
--- a/src/container_runner.py
+++ b/src/container_runner.py
@@ -150,7 +150,15 @@ class _Docker:
                 raise e
 
         # Prepare Docker run arguments
-        docker_args = ["-d", "--name", container_name, "-p", f"{host_port}:{container_port}"]
+        docker_args = [
+            "-v",
+            "/run/snapd.socket:/run/snapd.socket:ro",
+            "-d",
+            "--name",
+            container_name,
+            "-p",
+            f"{host_port}:{container_port}",
+        ]
         if env_vars:
             for key, value in env_vars.items():
                 docker_args.extend(["-e", f"{key}={value}"])

--- a/src/container_runner.py
+++ b/src/container_runner.py
@@ -156,6 +156,8 @@ class _Docker:
             "-d",
             "--name",
             container_name,
+            "--restart",
+            "always",
             "-p",
             f"{host_port}:{container_port}",
         ]

--- a/tests/unit/test_container_runner.py
+++ b/tests/unit/test_container_runner.py
@@ -260,6 +260,8 @@ class TestDocker(unittest.TestCase):
                 # Setup
                 inspect_expected_args = ["-f", "{{.State.Status}}", container_name]
                 run_expected_args = [
+                    "-v",
+                    "/run/snapd.socket:/run/snapd.socket:ro",
                     "-d",
                     "--name",
                     container_name,

--- a/tests/unit/test_container_runner.py
+++ b/tests/unit/test_container_runner.py
@@ -265,6 +265,8 @@ class TestDocker(unittest.TestCase):
                     "-d",
                     "--name",
                     container_name,
+                    "--restart",
+                    "always",
                     "-p",
                     f"{host_port}:{container_port}",
                 ]


### PR DESCRIPTION
- Mounting the snapd socket from the outer vm is required for the ratings service to make calls to snapd. Snapd cannot be run within a docker container.
- Having the docker container always restart fixes assumptions the charm makes of the managed container that were broken by docker containers exiting on failure (different behavior in rocks lead to these assumptions). Its very debatable if we want this to be the expected lifecycle, this just fixes docker container to comply with current assumptions.
