### PR TITLE
fix: skip tls if domain is empty

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,4 +32,4 @@ options:
     type: string
     default: ""
     description: 
-        Domain certbot should attempt to obtain tls certificates for.
+        Domain certbot should attempt to obtain tls certificates for. If empty, certbot will not be run.

--- a/src/container_runner.py
+++ b/src/container_runner.py
@@ -298,7 +298,9 @@ class ContainerRunner:
                 raise
 
         # Install certbot if it hasn't been already, provided domain is not an empty string
-        if (not hasattr(self, "_tls__obtained") or self._tls_obtained is False) and self._domain != "":
+        if (
+            not hasattr(self, "_tls__obtained") or self._tls_obtained is False
+        ) and self._domain != "":
             self._tls_obtained = True
             try:
                 _obtain_tls(self._email, self._domain)

--- a/src/container_runner.py
+++ b/src/container_runner.py
@@ -297,8 +297,8 @@ class ContainerRunner:
                 logger.error("Failed to remove container: %s", e)
                 raise
 
-        # Install certbot if it hasn't been already
-        if not hasattr(self, "_tls__obtained") or self._tls_obtained is False:
+        # Install certbot if it hasn't been already, provided domain is not an empty string
+        if (not hasattr(self, "_tls__obtained") or self._tls_obtained is False) and self._domain != "":
             self._tls_obtained = True
             try:
                 _obtain_tls(self._email, self._domain)


### PR DESCRIPTION
If the `domain` charm config value is left empty, certbot will not be run. This will make it easier for us to test a deployment without having to change dns settings.